### PR TITLE
Update create_account.py to require alphanumeric username

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 picamera2==0.3.27
+pyotp==2.9.0

--- a/scripts/create_account.py
+++ b/scripts/create_account.py
@@ -1,7 +1,14 @@
 import getpass
 import hashlib
 
-username = input('Enter username for new account: ')
+print('Your username must contain only letters and numbers.\n')
+
+while True:
+    username = input('Enter username for new account: ')
+    if username.isalnum():
+        break
+    else:
+        print('\nYour username contains invalid characters. Please try again, using only letters and numbers.\n')
 
 print('\nYour password will never be stored or sent as plaintext. After this script finishes, the plaintext will no longer be in memory either\n')
 
@@ -14,4 +21,3 @@ password_hash = hashlib.sha256(password.encode('utf-8')).hexdigest()
 with open('.users', 'a') as f:
     f.write('['+username+','+password_hash+']\n')
     f.close()
-

--- a/setup.sh
+++ b/setup.sh
@@ -2,3 +2,4 @@
 
 source env/bin/activate
 python -m pip install -r requirements.txt
+pip install git+https://github.com/glyh/qrterm


### PR DESCRIPTION
- Updated requirements.txt to include pyotp 2.9.0 and setup.sh to install the necessary qrterm module
- Checks to make sure username contains only alphanumeric characters. If not, will prompt the user to enter a new username until a valid username is entered.
